### PR TITLE
Fix missing module error in Bazel build

### DIFF
--- a/MastodonSDK/Package.swift
+++ b/MastodonSDK/Package.swift
@@ -107,7 +107,8 @@ let package = Package(
             name: "MastodonSDK",
             dependencies: [
                 .product(name: "NIOHTTP1", package: "swift-nio"),
-                "MastodonCommon"
+                "MastodonCommon",
+                "CoreDataStack"
             ]
         ),
         .target(

--- a/swift_deps_index.json
+++ b/swift_deps_index.json
@@ -194,6 +194,10 @@
       "src_type": "swift",
       "label": "@swiftpkg_mastodonsdk//:MastodonSDK.rspm",
       "package_identity": "mastodonsdk",
+      "dependencies": [
+        "CoreDataStack",
+        "MastodonCommon"
+      ],
       "product_memberships": [
         "MastodonSDK",
         "MastodonSDKDynamic"


### PR DESCRIPTION
Add `CoreDataStack` as a dependency to `MastodonSDK` to fix "no such module" build errors.

The `MastodonSDK` module's source files (`MastodonFeed.swift`, `MastodonStatus.swift`) were importing `CoreDataStack`, but `CoreDataStack` was not declared as a dependency for `MastodonSDK` in `Package.swift`. This caused Bazel to fail to resolve the module during compilation. This PR adds the missing dependency declaration and updates the `swift_deps_index.json` accordingly.